### PR TITLE
DELICE v2 — Provisioning Toolkit

### DIFF
--- a/.config/Kvantum/kvantum.kvconfig
+++ b/.config/Kvantum/kvantum.kvconfig
@@ -1,0 +1,2 @@
+[General]
+theme=KvArcDark

--- a/.config/gtk-3.0/settings.ini
+++ b/.config/gtk-3.0/settings.ini
@@ -1,5 +1,6 @@
 [Settings]
 gtk-theme-name=Arc-Dark
+gtk-application-prefer-dark-theme=1
 gtk-icon-theme-name=Papirus-Dark
 gtk-font-name=Lato 12
 gtk-cursor-theme-name=Adwaita

--- a/.config/rofi/config
+++ b/.config/rofi/config
@@ -1,1 +1,0 @@
-rofi.theme: /usr/share/rofi/themes/android_notification.rasi

--- a/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -8,7 +8,7 @@
         <property name="color1" type="empty"/>
         <property name="color2" type="empty"/>
         <property name="color-style" type="empty"/>
-        <property name="image-path" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+        <property name="image-path" type="string" value="DELICE_WALLPAPER"/>
         <property name="image-show" type="bool" value="true"/>
         <property name="last-image" type="empty"/>
         <property name="last-single-image" type="empty"/>
@@ -19,19 +19,19 @@
         <property name="color1" type="empty"/>
         <property name="color2" type="empty"/>
         <property name="color-style" type="empty"/>
-        <property name="image-path" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+        <property name="image-path" type="string" value="DELICE_WALLPAPER"/>
         <property name="image-show" type="bool" value="true"/>
         <property name="last-image" type="empty"/>
         <property name="last-single-image" type="empty"/>
         <property name="image-style" type="int" value="5"/>
       </property>
       <property name="monitor2" type="empty">
-        <property name="image-path" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+        <property name="image-path" type="string" value="DELICE_WALLPAPER"/>
         <property name="image-style" type="int" value="5"/>
         <property name="image-show" type="bool" value="true"/>
       </property>
       <property name="monitor3" type="empty">
-        <property name="image-path" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+        <property name="image-path" type="string" value="DELICE_WALLPAPER"/>
         <property name="image-style" type="int" value="5"/>
         <property name="image-show" type="bool" value="true"/>
       </property>
@@ -39,7 +39,7 @@
         <property name="workspace0" type="empty">
           <property name="color-style" type="int" value="0"/>
           <property name="image-style" type="int" value="0"/>
-          <property name="last-image" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+          <property name="last-image" type="string" value="DELICE_WALLPAPER"/>
           <property name="rgba1" type="array">
             <value type="double" value="0.12156862745098039"/>
             <value type="double" value="0.12156862745098039"/>
@@ -50,17 +50,17 @@
         <property name="workspace1" type="empty">
           <property name="color-style" type="int" value="1"/>
           <property name="image-style" type="int" value="5"/>
-          <property name="last-image" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+          <property name="last-image" type="string" value="DELICE_WALLPAPER"/>
         </property>
         <property name="workspace2" type="empty">
           <property name="color-style" type="int" value="1"/>
           <property name="image-style" type="int" value="5"/>
-          <property name="last-image" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+          <property name="last-image" type="string" value="DELICE_WALLPAPER"/>
         </property>
         <property name="workspace3" type="empty">
           <property name="color-style" type="int" value="1"/>
           <property name="image-style" type="int" value="5"/>
-          <property name="last-image" type="string" value="/usr/share/backgrounds/archlinux/simple.png"/>
+          <property name="last-image" type="string" value="DELICE_WALLPAPER"/>
         </property>
       </property>
     </property>

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test-*.log
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+## v2.0 — Provisioning Toolkit
+
+Evolution of DELICE from a fresh installation tool to a provisioning and maintenance
+toolkit capable of running on existing Debian machines (12 -> 13) without data loss.
+
+### Foundations
+
+- Extract shared functions into `lib/common.sh`
+- Refactor `post-install.sh`: error handling, quoted variables, `--dry-run` support
+- Remove dead code from `desktop-environment.sh`
+
+### Upgrade Safety
+
+- User config backup system (`~/delice-backup-YYYYMMDD/`)
+- Selective per-subdirectory sync instead of `rsync --delete` on `~/.config/`
+- `--backup-configs` and `--skip-backup` flags
+
+### Brave Browser
+
+- APT repo installation with GPG keyring (`--with-brave`)
+- Managed policies: Rewards/Wallet/VPN disabled, uBlock Origin force-installed
+- Recommended policies: DuckDuckGo, Shields, AI Chat off by default
+- Chrome uninstall prompt
+
+### Chrome Migration
+
+- Python script `tools/migrate-chrome-to-brave.py`
+- Migrate bookmarks (JSON), history (SQLite), passwords (AES-128-CBC)
+- Decrypt Chrome passwords via GNOME Keyring, re-encrypt for Brave
+- `--dry-run` mode and automatic profile backup
+- `--migrate-chrome` flag in `desktop-environment.sh`
+
+### Rustdesk
+
+- Install from GitHub releases (`--with-rustdesk`)
+- Configure server ID, relay, public key, permanent password
+- Defaults to self-hosted server laura.lgdweb.ovh
+
+### Dark Theme
+
+- Fix `QT_QPA_PLATFORMTHEME=kvantum` in `.profile`
+- Kvantum config with KvArcDark theme
+- Dotfiles cleanup (duplicates, unused shebang, empty case)
+
+### Wallpaper
+
+- `DELICE_WALLPAPER` placeholder in `xfce4-desktop.xml`
+- Dynamic path resolution via `configureWallpaper()` at install time
+
+### Test Framework
+
+- Configurable VM paths via `VIRT_MANAGER_DIR` env var
+- Remove dead code (unused variables, functions)
+- Inject new `configs/` and `tools/` directories into test VM
+- Clean up temporary files in trap handler
+
+### Documentation
+
+- Updated README with all new flags and features
+- Created CHANGELOG

--- a/README.md
+++ b/README.md
@@ -2,12 +2,8 @@
 
 **D**ebian **L**inux **I**nstall **C**ustom **E**asy
 
-Automated installation and configuration scripts for Debian with XFCE desktop environment.
-
-## Overview
-
-DELICE provides a reproducible way to set up a customized Debian system. It consists of installation
-scripts, configuration files, and an automated testing framework using QEMU/KVM.
+Automated provisioning and maintenance toolkit for Debian with XFCE desktop environment. Supports
+both fresh installations and upgrades on existing machines (Debian 12 -> 13) without data loss.
 
 ## Repository Structure
 
@@ -17,6 +13,13 @@ delice/
 ├── desktop-environment.sh    # XFCE desktop installation
 ├── test-vm.sh               # Automated VM testing
 ├── sources.list             # Debian Trixie sources
+├── lib/
+│   └── common.sh            # Shared shell functions
+├── configs/
+│   ├── brave-policies-managed.json      # Brave enforced policies
+│   └── brave-policies-recommended.json  # Brave recommended policies
+├── tools/
+│   └── migrate-chrome-to-brave.py       # Chrome data migration script
 ├── .config/                 # Application configs (alacritty, fastfetch, xfce4, etc.)
 ├── dotfiles/                # Shell dotfiles
 └── wallpapers/              # Desktop backgrounds
@@ -33,98 +36,109 @@ Base system configuration script that:
 - Configures system services (chrony, ufw, iwd, ModemManager)
 - Sets up firewall rules (deny incoming except SSH)
 - Configures timezone (Europe/Paris) and NTP
-- Enables system services: chrony, ssh, avahi-daemon, fstrim.timer, ufw, iwd, ModemManager
 
-**Key packages installed:**
-
-- System: vim, htop, git, bash-completion, rsync, curl, wget, chrony, ufw, iwd
-- Development: build-essential, libpam0g-dev, libxcb-xkb-dev
-- Filesystem: fdisk, mtools, xfsprogs, dosfstools, f2fs-tools, exfatprogs, zip, unzip, p7zip-full
-- Monitoring: duf, lm-sensors, lynis, systemd-zram-generator
+```bash
+./post-install.sh [--as-root] [--dry-run]
+```
 
 ### desktop-environment.sh
 
-XFCE desktop environment setup that:
+XFCE desktop environment setup with interactive prompts or CLI flags.
 
-- Installs XFCE desktop (task-xfce-desktop)
-- Configures LightDM with Slick Greeter
-- Installs video drivers (SPICE/QXL for VMs, optional Intel/Nvidia)
-- Sets up essential GUI applications
-- Installs and configures fonts (Nerd Fonts, Font Awesome)
-- Copies dotfiles and configurations to user home directory
+```bash
+./desktop-environment.sh [options]
+```
 
-**Desktop applications installed:**
+**Options:**
 
-- Browser: Firefox ESR
-- Office: LibreOffice
-- Utilities: pcmanfm, xarchiver, gparted, seahorse
-- Terminal: alacritty, fastfetch
-- Launcher: rofi
-- Media: gstreamer plugins
-
-### test-vm.sh
-
-Automated testing script for validating installation scripts in a VM environment.
+| Flag                       | Description                                                  |
+| -------------------------- | ------------------------------------------------------------ |
+| `--no-prompts`             | Non-interactive mode (use defaults or CLI flags)             |
+| `--theme`                  | Install theme packages and sync dotfiles                     |
+| `--drivers=PROFILE`        | Driver profile: vm, intel, nvidia, none                      |
+| `--with-brave`             | Install Brave browser with managed policies                  |
+| `--migrate-chrome`         | Migrate Chrome data (bookmarks, history, passwords) to Brave |
+| `--with-rustdesk`          | Install Rustdesk remote access                               |
+| `--rustdesk-server=HOST`   | Rustdesk relay server address                                |
+| `--rustdesk-key=KEY`       | Rustdesk server public key                                   |
+| `--rustdesk-password=PASS` | Rustdesk permanent password                                  |
+| `--with-office`            | Install office suite                                         |
+| `--with-multimedia[=LIST]` | Install multimedia packages (players,editors,burn,ripencode) |
+| `--with-development`       | Install development toolchain                                |
+| `--enable-bluetooth`       | Install Bluetooth support                                    |
+| `--backup-configs`         | Backup user configs before installing                        |
+| `--skip-backup`            | Skip backup prompt for existing installations                |
+| `--as-root`                | Run as root (testing only)                                   |
+| `--dry-run`                | Show planned actions without executing                       |
 
 **Features:**
 
-- Creates snapshot from base Debian image
-- Injects installation scripts into VM disk
-- Runs scripts automatically on VM boot
-- Captures full installation logs
-- Validates successful completion
-- Automatic cleanup on exit
+- XFCE desktop with LightDM/Slick Greeter
+- Dark theme: Arc-Dark (GTK) + KvArcDark (Qt/Kvantum)
+- Video drivers: VM (SPICE/QXL), Intel, Nvidia
+- Brave browser with enterprise policies (uBlock Origin forced, Rewards/Wallet/VPN disabled)
+- Chrome to Brave migration (bookmarks, history, encrypted passwords)
+- Rustdesk remote access with self-hosted server support
+- Backup system for existing installations
+- Selective config sync (no data loss on re-provisioning)
 
-**Usage:**
+## Upgrade Existing Machines
+
+DELICE can safely re-provision existing Debian installations:
+
+```bash
+# Backup configs, install desktop with Brave and Rustdesk
+./desktop-environment.sh --backup-configs --theme --with-brave --with-rustdesk
+```
+
+The backup system saves user data (browser profiles, SSH keys, keyrings, LibreOffice config) to
+`~/delice-backup-YYYYMMDD/` before applying changes. Config sync uses selective rsync per
+subdirectory instead of `rsync --delete` on the entire `~/.config/`.
+
+## Brave + Chrome Migration
+
+When both Chrome and Brave are detected, DELICE offers automatic migration:
+
+```bash
+./desktop-environment.sh --with-brave --migrate-chrome
+```
+
+Or run the migration script standalone:
+
+```bash
+python3 tools/migrate-chrome-to-brave.py [--dry-run]
+```
+
+Migrates: bookmarks (JSON copy), history (SQLite copy), passwords (AES-128-CBC decrypt/re-encrypt
+via GNOME Keyring).
+
+**Requirements:** `python3-secretstorage`, `python3-cryptography`
+
+## Testing
+
+Automated VM testing using QEMU/KVM:
 
 ```bash
 ./test-vm.sh              # Test post-install.sh only
 ./test-vm.sh --desktop    # Test both scripts
 ```
 
-**Requirements:**
+**Requirements:** QEMU/KVM, libvirt, virt-install, virt-customize, virt-cat
 
-- QEMU/KVM with libvirt
-- virt-install, virt-customize, virt-cat tools
-- Base Debian image at `/home/titux/virt-manager/disk/debian-stable-base.qcow2`
-
-**Test results:** Saved to `test-results-YYYYMMDD-HHMMSS.log`
-
-## Quick Start
-
-### Manual Installation
-
-```bash
-git clone <repository-url>
-cd delice
-
-# Install base system
-./post-install.sh
-
-# Install desktop environment (optional)
-./desktop-environment.sh
-```
-
-### Testing Before Installation
-
-```bash
-# Test in VM before running on real system
-./test-vm.sh --desktop
-```
+The `VIRT_MANAGER_DIR` environment variable configures the VM storage path (default:
+`/home/$USER/virt-manager`).
 
 ## Configuration Files
 
-The repository includes pre-configured dotfiles and settings:
+Pre-configured dotfiles and settings synced to `~/.config/`:
 
-- **Alacritty**: Terminal emulator configuration (`.config/alacritty/`)
+- **Alacritty**: Terminal emulator (`.config/alacritty/`)
 - **Fastfetch**: System information display (`.config/fastfetch/`)
-- **XFCE4**: Desktop settings, panel, keyboard shortcuts (`.config/xfce4/`)
-- **GTK**: Theme and file chooser settings (`.config/gtk-3.0/`)
+- **XFCE4**: Desktop, panel, keyboard shortcuts (`.config/xfce4/`)
+- **GTK 2/3**: Theme and file chooser (`.config/gtk-2.0/`, `.config/gtk-3.0/`)
+- **Kvantum**: Qt dark theme (`.config/Kvantum/`)
 - **Rofi**: Application launcher (`.config/rofi/`)
 - **htop**: System monitor (`.config/htop/`)
-
-These configurations are automatically copied to `~/.config/` by
-[desktop-environment.sh](desktop-environment.sh).
 
 ## System Requirements
 

--- a/configs/brave-policies-managed.json
+++ b/configs/brave-policies-managed.json
@@ -3,6 +3,6 @@
   "BraveWalletDisabled": true,
   "BraveVPNDisabled": true,
   "ExtensionInstallForcelist": [
-    "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+    "cjpalhdlnbpafiamejdnhcphjbkeiagm;https://clients2.google.com/service/update2/crx"
   ]
 }

--- a/configs/brave-policies-managed.json
+++ b/configs/brave-policies-managed.json
@@ -1,0 +1,8 @@
+{
+  "BraveRewardsDisabled": true,
+  "BraveWalletDisabled": true,
+  "BraveVPNDisabled": true,
+  "ExtensionInstallForcelist": [
+    "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+  ]
+}

--- a/configs/brave-policies-recommended.json
+++ b/configs/brave-policies-recommended.json
@@ -1,0 +1,7 @@
+{
+  "DefaultSearchProviderEnabled": true,
+  "DefaultSearchProviderSearchURL": "https://duckduckgo.com/?q={searchTerms}",
+  "DefaultSearchProviderName": "DuckDuckGo",
+  "BraveShieldsSettingDefault": "standard",
+  "BraveAIChatEnabled": false
+}

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -12,23 +12,23 @@
 readonly scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly projectRoot="${scriptDir}"
 
-# Video Driver Packages
-declare -a videoDriverPackages
-# Video drivers Nvidia See: https://wiki.debian.org/NvidiaGraphicsDrivers
+# shellcheck source=lib/common.sh
+source "${scriptDir}/lib/common.sh"
+
+# =============================================================================
+# PACKAGE LISTS
+# =============================================================================
+
+# Video drivers — See: https://wiki.debian.org/NvidiaGraphicsDrivers
 nvidiaDriverPackages="xserver-xorg-video-nouveau nvidia-vaapi-driver"
-# Video drivers Intel See: https://wiki.debian.org/GraphicsCard#Intel
+# Video drivers Intel — See: https://wiki.debian.org/GraphicsCard#Intel
 intelDriverPackages="libva2 intel-media-va-driver xserver-xorg-video-intel"
-# Virtual Machine (kvm) video drivers See: https://wiki.debian.org/KVM
+# Virtual Machine (kvm) video drivers — See: https://wiki.debian.org/KVM
 virtualMachineDriverPackages="spice-vdagent xserver-xorg-video-qxl xserver-xorg-video-vesa"
-# Video drivers OpenGL See: https://wiki.debian.org/GraphicsCard
-genericDriverPackages="mesa-utils xserver-xorg-video-vesa"
-# Hardware Video accel See: https://wiki.debian.org/HardwareVideoAcceleration
+# Hardware Video accel — See: https://wiki.debian.org/HardwareVideoAcceleration
 hdwVideoAccelPackages="mesa-va-drivers mesa-vdpau-drivers vainfo vdpauinfo"
 
-declare -a desktopEnvPackages
-checkInstallDesktopXfce=0
-desktopEnvironment=""
-# Xfce desktop environment See: https://wiki.debian.org/Xfce
+# Xfce desktop environment — See: https://wiki.debian.org/Xfce
 desktopXfcePackages="task-xfce-desktop accountsservice slick-greeter"
 
 # Base X.Org and system packages
@@ -39,17 +39,12 @@ baseXorgPackages="xbindkeys xdg-utils xdg-user-dirs xdg-user-dirs-gtk xcompmgr n
 browserPackages="firefox-esr firefox-esr-l10n-fr"
 
 # System utilities
-utilityPackages="fastfetch alacritty rofi pcmanfm libfm-tools libusbmuxd-tools feh dex xarchiver gparted gphoto2 sshfs nfs-common fuseiso file-roller timeshift gvfs gvfs-backends gvfs-fuse dunst libnotify-bin figlet qimgv redshift cpu-x cryptsetup pavucontrol alsa-utils pulseaudio ffmpeg ffmpegthumbnailer rsync"
+utilityPackages="fastfetch alacritty rofi pcmanfm libfm-tools libusbmuxd-tools feh dex xarchiver gparted gphoto2 sshfs nfs-common fuseiso file-roller timeshift gvfs gvfs-backends gvfs-fuse dunst libnotify-bin figlet qimgv redshift cpu-x cryptsetup pavucontrol alsa-utils pulseaudio ffmpeg ffmpegthumbnailer rsync seahorse gnupg"
 
 # Fonts and themes See: https://wiki.debian.org/Fonts
 themePackages="lxappearance fonts-recommended fonts-ubuntu fonts-font-awesome fonts-lmodern fonts-terminus papirus-icon-theme gtk-update-icon-cache arc-theme adwaita-qt qt5-style-kvantum"
 
-# Multimedia packages: readers/viewers, editors/capture, rip/encode, burn for images, audio, video
-declare -a multimediaPackages
-checkInstallMultimediaReaders=0
-checkInstallMultimediaEditors=0
-checkInstallMultimediaRipencode=0
-checkInstallMultimediaBurn=0
+# Multimedia packages: readers/viewers, editors/capture, rip/encode, burn
 multimediaReadersPackages="vlc quodlibet shotwell evince mpd playerctl libdvd-pkg libdvdread-dev libdvdnav-dev libcdio-dev"
 multimediaEditorsPackages="gimp inkscape scour"
 multimediaRipencodePackages="asunder handbrake handbrake-cli lame ogmtools faac flac x265 x264"
@@ -57,15 +52,12 @@ multimediaBurnPackages="brasero dvdauthor dvdbackup dvd+rw-tools libisoburn-dev"
 # Audio/Video codec and GStreamer support
 audioVideoCodecGst="gstreamer1.0-x gstreamer1.0-libav"
 
-officePackages="seahorse gnupg ghostscript libreoffice-gtk3 libreoffice-l10n-fr libreoffice-help-fr galculator l3afpad ghostwriter libtext-multimarkdown-perl cmark pandoc"
+officePackages="ghostscript libreoffice-gtk3 libreoffice-l10n-fr libreoffice-help-fr galculator l3afpad ghostwriter libtext-multimarkdown-perl cmark pandoc"
 
 # Development Packages
-declare -a developmentPackages
-checkInstallDevelopmentToolchain=0
 developmentToolchainPackages="build-essential"
 
 bluetoothPackages="bluez bluez-firmware bluez-tools pulseaudio-module-bluetooth blueman"
-checkInstallBluetooth=0
 
 # =============================================================================
 # SCRIPT CONFIGURATION VARIABLES
@@ -100,52 +92,8 @@ declare -a postInstallTasks=()          # Tasks to execute after package install
 declare -a summaryLines=()              # Summary information for user review
 
 # =============================================================================
-# UTILITY FUNCTIONS
-# =============================================================================
-
-# Display formatted message with green color and borders
-# Usage: printMessage "Your message here"
-printMessage() {
-  local message=$1
-  if command -v tput >/dev/null 2>&1; then
-    tput setaf 2
-  fi
-  echo "-------------------------------------------"
-  echo "$message"
-  echo "-------------------------------------------"
-  if command -v tput >/dev/null 2>&1; then
-    tput sgr0
-  fi
-}
-
-# Log warning message to stderr
-# Usage: logWarning "Warning message"
-logWarning() {
-  local message=$1
-  echo "WARNING: $message" >&2
-}
-
-# Log error message to stderr
-# Usage: logError "Error message"
-logError() {
-  local message=$1
-  echo "ERROR: $message" >&2
-}
-
-# =============================================================================
 # ARRAY MANIPULATION FUNCTIONS
 # =============================================================================
-
-# Append multiple items to an array
-# Usage: appendPackages arrayName "item1" "item2" "item3"
-appendPackages() {
-  local -n target=$1
-  shift
-  local item
-  for item in "$@"; do
-    target+=("$item")
-  done
-}
 
 # Add item to array only if it doesn't already exist
 # Usage: addUnique arrayName "itemValue"
@@ -175,29 +123,6 @@ deduplicateArray() {
     fi
   done
   target=("${unique[@]}")
-}
-
-# =============================================================================
-# ERROR HANDLING AND VALIDATION
-# =============================================================================
-
-# Enable strict error handling with detailed error reporting
-# Sets up trap to show exact line and command that failed
-setupErrorHandling() {
-  set -euo pipefail
-  trap 'status=$?; echo "Error on line ${LINENO}: ${BASH_COMMAND}" >&2; exit $status' ERR
-}
-
-# Ensure script is not run as root user
-# The script needs to run as regular user with sudo privileges for proper file ownership
-requireUserContext() {
-  if [[ $enableRunAsRoot -eq 1 ]]; then
-    return
-  fi
-  if [[ $EUID -eq 0 ]]; then
-    logError "Run this script as a regular user with sudo access."
-    exit 1
-  fi
 }
 
 # =============================================================================

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -76,6 +76,10 @@ backupConfigs=0                # Flag to backup user configs before installing
 skipBackup=0                   # Flag to skip backup prompt for existing installations
 installBrave=0                 # Flag to install Brave browser
 migrateChrome=0                # Flag to migrate Chrome data to Brave
+installRustdesk=0              # Flag to install Rustdesk remote access
+rustdeskServer="laura.lgdweb.ovh"   # Rustdesk server ID and relay address
+rustdeskKey="QrrSBjpl1L1nbJNqjCkNfrKsSOSxYappCZavaPp1db8="  # Rustdesk server public key
+rustdeskPassword=""            # Rustdesk permanent password (set via CLI)
 enableRunAsRoot=0              # Flag to allow running script as root (not recommended)
 
 # Default selections
@@ -93,6 +97,7 @@ bluetoothCliOverride=0         # Skip Bluetooth support prompt
 backupCliOverride=0            # Skip backup prompt
 braveCliOverride=0             # Skip Brave browser prompt
 migrateCliOverride=0           # Skip Chrome migration prompt
+rustdeskCliOverride=0          # Skip Rustdesk prompt
 
 # Dynamic arrays populated during execution
 declare -a selectedMultimediaGroups=()  # User-selected multimedia groups
@@ -233,6 +238,10 @@ Options:
   --drivers=<profile>          Driver profile: vm, intel, nvidia, none (default: vm)
   --with-brave                 Install Brave browser with managed policies
   --migrate-chrome             Migrate Chrome data (bookmarks, history, passwords) to Brave
+  --with-rustdesk              Install Rustdesk remote access
+  --rustdesk-server=HOST       Rustdesk relay server address
+  --rustdesk-key=KEY           Rustdesk server public key
+  --rustdesk-password=PASS     Rustdesk permanent password
   --with-office                Install office suite packages
   --with-multimedia            Install all multimedia groups
   --with-multimedia=<list>     Comma-separated multimedia groups (players,editors,burn,ripencode)
@@ -295,6 +304,19 @@ parseArgs() {
       --migrate-chrome)
         migrateChrome=1
         migrateCliOverride=1
+      ;;
+      --with-rustdesk)
+        installRustdesk=1
+        rustdeskCliOverride=1
+      ;;
+      --rustdesk-server=*)
+        rustdeskServer="${1#*=}"
+      ;;
+      --rustdesk-key=*)
+        rustdeskKey="${1#*=}"
+      ;;
+      --rustdesk-password=*)
+        rustdeskPassword="${1#*=}"
       ;;
       --with-office)
         installOffice=1
@@ -519,6 +541,15 @@ promptChromeMigration() {
   askYesNo "Migrate Chrome data (bookmarks, history, passwords) to Brave? [y/N]" migrateChrome "n"
 }
 
+# Prompt user about Rustdesk remote access installation
+# Skipped if Rustdesk flag was specified via command line (--with-rustdesk)
+promptRustdeskInstall() {
+  if [[ $rustdeskCliOverride -eq 1 ]]; then
+    return
+  fi
+  askYesNo "Install Rustdesk remote access? [y/N]" installRustdesk "n"
+}
+
 promptBackupConfigs() {
   if [[ $backupCliOverride -eq 1 ]]; then
     return
@@ -543,6 +574,7 @@ maybePromptUser() {
   promptBluetoothSupport
   promptBraveInstall
   promptChromeMigration
+  promptRustdeskInstall
 }
 
 normalizeMultimediaSelection() {
@@ -716,6 +748,13 @@ buildPackagePlan() {
   fi
   addSummary "$bluetoothSummary"
 
+  local rustdeskSummary="Rustdesk: skipped"
+  if [[ $installRustdesk -eq 1 ]]; then
+    rustdeskSummary="Rustdesk: will download from GitHub"
+    queuePostInstallTask installRustdesk
+  fi
+  addSummary "$rustdeskSummary"
+
   if [[ $needDvdReconfigure -eq 1 ]]; then
     queuePostInstallTask configureDvdcss
   fi
@@ -819,6 +858,51 @@ configureWallpaper() {
   local wallpaperPath="$HOME/wallpapers/${defaultWallpaper}"
   printMessage "Configuring wallpaper: ${defaultWallpaper}"
   sed -i "s|DELICE_WALLPAPER|${wallpaperPath}|g" "$desktopXml"
+}
+
+# Download and install Rustdesk from GitHub releases
+# Configures relay server and permanent password if provided
+installRustdesk() {
+  printMessage "Installing Rustdesk"
+  local tmpDeb
+  tmpDeb=$(mktemp --suffix=.deb)
+
+  # Get latest release .deb URL for amd64
+  local downloadUrl
+  downloadUrl=$(curl -fsSL https://api.github.com/repos/rustdesk/rustdesk/releases/latest \
+    | grep -oP '"browser_download_url":\s*"\K[^"]+amd64\.deb(?=")' \
+    | grep -v sctgdesk \
+    | head -1)
+
+  if [[ -z "$downloadUrl" ]]; then
+    logError "Failed to find Rustdesk .deb download URL"
+    rm -f "$tmpDeb"
+    return 1
+  fi
+
+  printMessage "Downloading Rustdesk from ${downloadUrl}"
+  curl -fsSL -o "$tmpDeb" "$downloadUrl"
+  sudo dpkg -i "$tmpDeb" || sudo apt install -f -y
+  rm -f "$tmpDeb"
+
+  if [[ -n "$rustdeskServer" ]]; then
+    printMessage "Configuring Rustdesk server: ${rustdeskServer}"
+    rustdesk --option custom-rendezvous-server "${rustdeskServer}"
+    rustdesk --option relay-server "${rustdeskServer}"
+  fi
+
+  if [[ -n "$rustdeskKey" ]]; then
+    printMessage "Configuring Rustdesk server key"
+    rustdesk --option key "${rustdeskKey}"
+  fi
+
+  if [[ -n "$rustdeskPassword" ]]; then
+    printMessage "Setting Rustdesk permanent password"
+    rustdesk --password "${rustdeskPassword}"
+  fi
+
+  sudo systemctl enable --now rustdesk
+  printMessage "Rustdesk installed and enabled"
 }
 
 # Run Chrome to Brave data migration script

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -37,6 +37,7 @@ baseXorgPackages="xbindkeys xdg-utils xdg-user-dirs xdg-user-dirs-gtk xcompmgr n
 
 # Web browser packages
 browserPackages="firefox-esr firefox-esr-l10n-fr"
+bravePackages="brave-browser"
 
 # System utilities
 utilityPackages="fastfetch alacritty rofi pcmanfm libfm-tools libusbmuxd-tools feh dex xarchiver gparted gphoto2 sshfs nfs-common fuseiso file-roller timeshift gvfs gvfs-backends gvfs-fuse dunst libnotify-bin figlet qimgv redshift cpu-x cryptsetup pavucontrol alsa-utils pulseaudio ffmpeg ffmpegthumbnailer rsync seahorse gnupg"
@@ -72,6 +73,7 @@ enableBluetooth=0              # Flag to install and enable Bluetooth support
 needDvdReconfigure=0           # Flag to reconfigure DVD CSS support
 backupConfigs=0                # Flag to backup user configs before installing
 skipBackup=0                   # Flag to skip backup prompt for existing installations
+installBrave=0                 # Flag to install Brave browser
 enableRunAsRoot=0              # Flag to allow running script as root (not recommended)
 
 # Default selections
@@ -87,6 +89,7 @@ multimediaCliOverride=0        # Skip multimedia selection prompt
 developmentCliOverride=0       # Skip development tools prompt
 bluetoothCliOverride=0         # Skip Bluetooth support prompt
 backupCliOverride=0            # Skip backup prompt
+braveCliOverride=0             # Skip Brave browser prompt
 
 # Dynamic arrays populated during execution
 declare -a selectedMultimediaGroups=()  # User-selected multimedia groups
@@ -225,6 +228,7 @@ Options:
   --theme                      Install theme packages and sync dotfiles
   --desktop=<name>             Desktop profile to install (default: xfce)
   --drivers=<profile>          Driver profile: vm, intel, nvidia, none (default: vm)
+  --with-brave                 Install Brave browser with managed policies
   --with-office                Install office suite packages
   --with-multimedia            Install all multimedia groups
   --with-multimedia=<list>     Comma-separated multimedia groups (players,editors,burn,ripencode)
@@ -279,6 +283,10 @@ parseArgs() {
       --drivers=*)
         selectedDriverProfile="${1#*=}"
         driverCliOverride=1
+      ;;
+      --with-brave)
+        installBrave=1
+        braveCliOverride=1
       ;;
       --with-office)
         installOffice=1
@@ -478,6 +486,15 @@ promptBluetoothSupport() {
   askYesNo "Install Bluetooth support? [y/N]" enableBluetooth "n"
 }
 
+# Prompt user about Brave browser installation
+# Skipped if Brave flag was specified via command line (--with-brave)
+promptBraveInstall() {
+  if [[ $braveCliOverride -eq 1 ]]; then
+    return
+  fi
+  askYesNo "Install Brave browser? [y/N]" installBrave "n"
+}
+
 promptBackupConfigs() {
   if [[ $backupCliOverride -eq 1 ]]; then
     return
@@ -500,6 +517,7 @@ maybePromptUser() {
   promptOfficeSuite
   promptDevelopmentGroups
   promptBluetoothSupport
+  promptBraveInstall
 }
 
 normalizeMultimediaSelection() {
@@ -597,6 +615,14 @@ buildPackagePlan() {
   packagesToInstall+=($browserPackages)
   addSummary "Browsers: ${browserPackages}"
 
+  local braveSummary="Brave: skipped"
+  if [[ $installBrave -eq 1 ]]; then
+    packagesToInstall+=($bravePackages)
+    braveSummary="Brave: ${bravePackages}"
+    queuePostInstallTask configureBravePolicies
+  fi
+  addSummary "$braveSummary"
+
   local themeSummary="Themes: skipped"
   if [[ $installTheme -eq 1 ]]; then
     packagesToInstall+=($themePackages)
@@ -681,6 +707,20 @@ printSummary() {
 # INSTALLATION FUNCTIONS
 # =============================================================================
 
+# Add Brave browser APT repository and GPG keyring
+# See: https://brave.com/linux/#debian-ubuntu-mint
+# Idempotent: skips if keyring already exists
+setupBraveRepo() {
+  local keyringPath="/usr/share/keyrings/brave-browser-archive-keyring.gpg"
+  if [[ -f "$keyringPath" ]]; then
+    printMessage "Brave repository already configured, skipping"
+    return
+  fi
+  printMessage "Adding Brave browser APT repository"
+  sudo curl -fsSLo "$keyringPath" https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+  echo "deb [signed-by=${keyringPath}] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list > /dev/null
+}
+
 # Install all selected packages using APT package manager
 # Updates package index and installs packages non-interactively
 installPackages() {
@@ -748,6 +788,34 @@ configureWallpaper() {
   sed -i "s|DELICE_WALLPAPER|${wallpaperPath}|g" "$desktopXml"
 }
 
+# Deploy Brave browser enterprise policies
+# Copies managed (enforced) and recommended (user-overridable) policy files
+configureBravePolicies() {
+  printMessage "Deploying Brave browser policies"
+  sudo mkdir -p /etc/brave/policies/managed /etc/brave/policies/recommended
+  sudo cp "${projectRoot}/configs/brave-policies-managed.json" /etc/brave/policies/managed/policies.json
+  sudo cp "${projectRoot}/configs/brave-policies-recommended.json" /etc/brave/policies/recommended/policies.json
+  promptChromeUninstall
+}
+
+# Offer to uninstall Google Chrome if detected
+# Only prompts in interactive mode — never auto-removes
+promptChromeUninstall() {
+  if ! dpkg -l google-chrome-stable 2>/dev/null | grep -q "^ii"; then
+    return
+  fi
+  if [[ "$promptMode" == "disabled" ]]; then
+    logWarning "Google Chrome detected. Use 'apt remove google-chrome-stable' to uninstall manually."
+    return
+  fi
+  local removeChrome=0
+  askYesNo "Google Chrome detected. Uninstall it? [y/N]" removeChrome "n"
+  if [[ $removeChrome -eq 1 ]]; then
+    printMessage "Removing Google Chrome"
+    sudo apt remove -y google-chrome-stable
+  fi
+}
+
 # Configure DVD CSS decryption support
 # See: https://wiki.debian.org/DVD
 configureDvdcss() {
@@ -796,6 +864,9 @@ main() {
   if [[ $dryRun -eq 1 ]]; then
     logWarning "Dry run enabled; skipping installation."
     return
+  fi
+  if [[ $installBrave -eq 1 ]]; then
+    setupBraveRepo
   fi
   installPackages
   executePostInstallTasks

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -717,7 +717,7 @@ installThemeAssets() {
   printMessage "Syncing theme and desktop configuration"
   mkdir -p "$HOME/.config"
 
-  local managedConfigDirs=(alacritty fastfetch galculator gtk-2.0 gtk-3.0 htop l3afpad pcmanfm rofi xfce4)
+  local managedConfigDirs=(alacritty fastfetch galculator gtk-2.0 gtk-3.0 htop Kvantum l3afpad pcmanfm rofi xfce4)
   local dir
   for dir in "${managedConfigDirs[@]}"; do
     if [[ -d "${projectRoot}/.config/${dir}" ]]; then

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -38,6 +38,7 @@ baseXorgPackages="xbindkeys xdg-utils xdg-user-dirs xdg-user-dirs-gtk xcompmgr n
 # Web browser packages
 browserPackages="firefox-esr firefox-esr-l10n-fr"
 bravePackages="brave-browser"
+migrationDeps="python3-secretstorage python3-cryptography"
 
 # System utilities
 utilityPackages="fastfetch alacritty rofi pcmanfm libfm-tools libusbmuxd-tools feh dex xarchiver gparted gphoto2 sshfs nfs-common fuseiso file-roller timeshift gvfs gvfs-backends gvfs-fuse dunst libnotify-bin figlet qimgv redshift cpu-x cryptsetup pavucontrol alsa-utils pulseaudio ffmpeg ffmpegthumbnailer rsync seahorse gnupg"
@@ -74,6 +75,7 @@ needDvdReconfigure=0           # Flag to reconfigure DVD CSS support
 backupConfigs=0                # Flag to backup user configs before installing
 skipBackup=0                   # Flag to skip backup prompt for existing installations
 installBrave=0                 # Flag to install Brave browser
+migrateChrome=0                # Flag to migrate Chrome data to Brave
 enableRunAsRoot=0              # Flag to allow running script as root (not recommended)
 
 # Default selections
@@ -90,6 +92,7 @@ developmentCliOverride=0       # Skip development tools prompt
 bluetoothCliOverride=0         # Skip Bluetooth support prompt
 backupCliOverride=0            # Skip backup prompt
 braveCliOverride=0             # Skip Brave browser prompt
+migrateCliOverride=0           # Skip Chrome migration prompt
 
 # Dynamic arrays populated during execution
 declare -a selectedMultimediaGroups=()  # User-selected multimedia groups
@@ -229,6 +232,7 @@ Options:
   --desktop=<name>             Desktop profile to install (default: xfce)
   --drivers=<profile>          Driver profile: vm, intel, nvidia, none (default: vm)
   --with-brave                 Install Brave browser with managed policies
+  --migrate-chrome             Migrate Chrome data (bookmarks, history, passwords) to Brave
   --with-office                Install office suite packages
   --with-multimedia            Install all multimedia groups
   --with-multimedia=<list>     Comma-separated multimedia groups (players,editors,burn,ripencode)
@@ -287,6 +291,10 @@ parseArgs() {
       --with-brave)
         installBrave=1
         braveCliOverride=1
+      ;;
+      --migrate-chrome)
+        migrateChrome=1
+        migrateCliOverride=1
       ;;
       --with-office)
         installOffice=1
@@ -495,6 +503,22 @@ promptBraveInstall() {
   askYesNo "Install Brave browser? [y/N]" installBrave "n"
 }
 
+# Prompt user about Chrome to Brave migration
+# Only prompts if both Chrome and Brave are detected
+# Skipped if migration flag was specified via command line (--migrate-chrome)
+promptChromeMigration() {
+  if [[ $migrateCliOverride -eq 1 ]]; then
+    return
+  fi
+  if ! dpkg -l google-chrome-stable 2>/dev/null | grep -q "^ii"; then
+    return
+  fi
+  if [[ $installBrave -eq 0 ]] && ! dpkg -l brave-browser 2>/dev/null | grep -q "^ii"; then
+    return
+  fi
+  askYesNo "Migrate Chrome data (bookmarks, history, passwords) to Brave? [y/N]" migrateChrome "n"
+}
+
 promptBackupConfigs() {
   if [[ $backupCliOverride -eq 1 ]]; then
     return
@@ -518,6 +542,7 @@ maybePromptUser() {
   promptDevelopmentGroups
   promptBluetoothSupport
   promptBraveInstall
+  promptChromeMigration
 }
 
 normalizeMultimediaSelection() {
@@ -622,6 +647,14 @@ buildPackagePlan() {
     queuePostInstallTask configureBravePolicies
   fi
   addSummary "$braveSummary"
+
+  local migrationSummary="Chrome migration: skipped"
+  if [[ $migrateChrome -eq 1 ]]; then
+    packagesToInstall+=($migrationDeps)
+    migrationSummary="Chrome migration: enabled (deps: ${migrationDeps})"
+    queuePostInstallTask runChromeMigration
+  fi
+  addSummary "$migrationSummary"
 
   local themeSummary="Themes: skipped"
   if [[ $installTheme -eq 1 ]]; then
@@ -786,6 +819,12 @@ configureWallpaper() {
   local wallpaperPath="$HOME/wallpapers/${defaultWallpaper}"
   printMessage "Configuring wallpaper: ${defaultWallpaper}"
   sed -i "s|DELICE_WALLPAPER|${wallpaperPath}|g" "$desktopXml"
+}
+
+# Run Chrome to Brave data migration script
+runChromeMigration() {
+  printMessage "Running Chrome to Brave migration"
+  python3 "${projectRoot}/tools/migrate-chrome-to-brave.py"
 }
 
 # Deploy Brave browser enterprise policies

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -867,11 +867,11 @@ installRustdesk() {
   local tmpDeb
   tmpDeb=$(mktemp --suffix=.deb)
 
-  # Get latest release .deb URL for amd64
+  # Get latest release .deb URL for x86_64 (exclude sciter variant)
   local downloadUrl
   downloadUrl=$(curl -fsSL https://api.github.com/repos/rustdesk/rustdesk/releases/latest \
-    | grep -oP '"browser_download_url":\s*"\K[^"]+amd64\.deb(?=")' \
-    | grep -v sctgdesk \
+    | grep -oP '"browser_download_url":\s*"\K[^"]+x86_64\.deb(?=")' \
+    | grep -v sciter \
     | head -1)
 
   if [[ -z "$downloadUrl" ]]; then
@@ -976,6 +976,12 @@ main() {
   setupErrorHandling
   parseArgs "$@"
   requireUserContext
+
+  # Fix HOME when running via sudo (sudo resets HOME to /root)
+  if [[ -n "${SUDO_USER:-}" && "$HOME" == "/root" ]]; then
+    export HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+    printMessage "Running as root for user ${SUDO_USER}, using HOME=${HOME}"
+  fi
   maybePromptUser
   normalizeMultimediaSelection
   validateConfiguration

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -304,6 +304,9 @@ parseArgs() {
       --migrate-chrome)
         migrateChrome=1
         migrateCliOverride=1
+        # Chrome migration requires Brave to be installed
+        installBrave=1
+        braveCliOverride=1
       ;;
       --with-rustdesk)
         installRustdesk=1
@@ -781,16 +784,18 @@ printSummary() {
 
 # Add Brave browser APT repository and GPG keyring
 # See: https://brave.com/linux/#debian-ubuntu-mint
-# Idempotent: skips if keyring already exists
+# Idempotent: skips if both keyring and APT source are correctly configured
 setupBraveRepo() {
   local keyringPath="/usr/share/keyrings/brave-browser-archive-keyring.gpg"
-  if [[ -f "$keyringPath" ]]; then
+  local sourceListPath="/etc/apt/sources.list.d/brave-browser-release.list"
+  if [[ -f "$keyringPath" && -f "$sourceListPath" ]] && \
+     grep -q "https://brave-browser-apt-release.s3.brave.com" "$sourceListPath" 2>/dev/null; then
     printMessage "Brave repository already configured, skipping"
     return
   fi
   printMessage "Adding Brave browser APT repository"
   sudo curl -fsSLo "$keyringPath" https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-  echo "deb [signed-by=${keyringPath}] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list > /dev/null
+  echo "deb [signed-by=${keyringPath}] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee "$sourceListPath" > /dev/null
 }
 
 # Install all selected packages using APT package manager

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -77,6 +77,7 @@ enableRunAsRoot=0              # Flag to allow running script as root (not recom
 # Default selections
 selectedDriverProfile="vm"      # Default video driver profile (vm, intel, nvidia, none)
 selectedDesktop="xfce"         # Default desktop environment
+defaultWallpaper="rod-long-8i7F4BadwNo-unsplash.jpg"  # Default wallpaper from wallpapers/
 
 # CLI override flags - prevent prompts when set via command line
 driverCliOverride=0            # Skip driver selection prompt
@@ -730,6 +731,21 @@ installThemeAssets() {
     mkdir -p "$HOME/wallpapers"
     rsync -rtv --delete "${projectRoot}/wallpapers/" "$HOME/wallpapers/"
   fi
+
+  configureWallpaper
+}
+
+# Resolve wallpaper placeholder in XFCE desktop configuration
+# Replaces DELICE_WALLPAPER with actual path to user's wallpaper
+configureWallpaper() {
+  local desktopXml="$HOME/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml"
+  if [[ ! -f "$desktopXml" ]]; then
+    logWarning "xfce4-desktop.xml not found, skipping wallpaper configuration."
+    return
+  fi
+  local wallpaperPath="$HOME/wallpapers/${defaultWallpaper}"
+  printMessage "Configuring wallpaper: ${defaultWallpaper}"
+  sed -i "s|DELICE_WALLPAPER|${wallpaperPath}|g" "$desktopXml"
 }
 
 # Configure DVD CSS decryption support

--- a/desktop-environment.sh
+++ b/desktop-environment.sh
@@ -70,6 +70,8 @@ installTheme=0                 # Flag to install theme packages and sync dotfile
 installOffice=0                # Flag to install office suite packages
 enableBluetooth=0              # Flag to install and enable Bluetooth support
 needDvdReconfigure=0           # Flag to reconfigure DVD CSS support
+backupConfigs=0                # Flag to backup user configs before installing
+skipBackup=0                   # Flag to skip backup prompt for existing installations
 enableRunAsRoot=0              # Flag to allow running script as root (not recommended)
 
 # Default selections
@@ -83,6 +85,7 @@ officeCliOverride=0            # Skip office suite prompt
 multimediaCliOverride=0        # Skip multimedia selection prompt
 developmentCliOverride=0       # Skip development tools prompt
 bluetoothCliOverride=0         # Skip Bluetooth support prompt
+backupCliOverride=0            # Skip backup prompt
 
 # Dynamic arrays populated during execution
 declare -a selectedMultimediaGroups=()  # User-selected multimedia groups
@@ -126,6 +129,58 @@ deduplicateArray() {
 }
 
 # =============================================================================
+# BACKUP FUNCTIONS
+# =============================================================================
+
+# Detect if a desktop environment is already installed
+# Returns 0 if ~/.config/xfce4/ exists (existing install), 1 otherwise
+detectExistingInstall() {
+  [[ -d "$HOME/.config/xfce4" ]]
+}
+
+# Backup user configuration directories before re-provisioning
+# Creates ~/delice-backup-YYYYMMDD/ and rsyncs existing user configs into it
+backupUserConfigs() {
+  local backupDir="$HOME/delice-backup-$(date +%Y%m%d)"
+  local dirsToBackup=(
+    "$HOME/.mozilla"
+    "$HOME/.config/google-chrome"
+    "$HOME/.config/BraveSoftware"
+    "$HOME/.config/libreoffice"
+    "$HOME/.local/share/keyrings"
+    "$HOME/.ssh"
+    "$HOME/.thunderbird"
+  )
+
+  local existingDirs=()
+  local dir
+  for dir in "${dirsToBackup[@]}"; do
+    if [[ -d "$dir" ]]; then
+      existingDirs+=("$dir")
+    fi
+  done
+
+  if [[ ${#existingDirs[@]} -eq 0 ]]; then
+    logWarning "No user config directories found to backup."
+    return
+  fi
+
+  printMessage "Estimating backup size"
+  du -sh "${existingDirs[@]}"
+
+  printMessage "Backing up user configs to ${backupDir}"
+  mkdir -p "$backupDir"
+
+  for dir in "${existingDirs[@]}"; do
+    local relative="${dir#"$HOME"/}"
+    mkdir -p "$backupDir/$(dirname "$relative")"
+    rsync -av "$dir/" "$backupDir/$relative/"
+  done
+
+  printMessage "Backup complete: ${backupDir}"
+}
+
+# =============================================================================
 # COMMAND LINE PARSING FUNCTIONS
 # =============================================================================
 
@@ -164,6 +219,8 @@ Usage: desktop-environment.sh [options]
 
 Options:
   --no-prompts                 Disable interactive prompts (use defaults or CLI selections)
+  --backup-configs             Backup user configs before installing
+  --skip-backup                Skip backup prompt for existing installations
   --theme                      Install theme packages and sync dotfiles
   --desktop=<name>             Desktop profile to install (default: xfce)
   --drivers=<profile>          Driver profile: vm, intel, nvidia, none (default: vm)
@@ -202,6 +259,14 @@ parseArgs() {
     case "$1" in
       --no-prompts)
         promptMode="disabled"
+      ;;
+      --backup-configs)
+        backupConfigs=1
+        backupCliOverride=1
+      ;;
+      --skip-backup)
+        skipBackup=1
+        backupCliOverride=1
       ;;
       --theme)
         installTheme=1
@@ -412,10 +477,22 @@ promptBluetoothSupport() {
   askYesNo "Install Bluetooth support? [y/N]" enableBluetooth "n"
 }
 
+promptBackupConfigs() {
+  if [[ $backupCliOverride -eq 1 ]]; then
+    return
+  fi
+  if ! detectExistingInstall; then
+    return
+  fi
+  logWarning "Existing desktop installation detected."
+  askYesNo "Backup user configs before proceeding? [Y/n]" backupConfigs "y"
+}
+
 maybePromptUser() {
   if [[ "$promptMode" == "disabled" ]]; then
     return
   fi
+  promptBackupConfigs
   promptDriverProfile
   promptThemeOption
   promptMultimediaGroups
@@ -639,9 +716,16 @@ EOF
 installThemeAssets() {
   printMessage "Syncing theme and desktop configuration"
   mkdir -p "$HOME/.config"
-  if [[ -d "${projectRoot}/.config" ]]; then
-    rsync -rtv --delete "${projectRoot}/.config/" "$HOME/.config/"
-  fi
+
+  local managedConfigDirs=(alacritty fastfetch galculator gtk-2.0 gtk-3.0 htop l3afpad pcmanfm rofi xfce4)
+  local dir
+  for dir in "${managedConfigDirs[@]}"; do
+    if [[ -d "${projectRoot}/.config/${dir}" ]]; then
+      mkdir -p "$HOME/.config/${dir}"
+      rsync -rtv --delete "${projectRoot}/.config/${dir}/" "$HOME/.config/${dir}/"
+    fi
+  done
+
   if [[ -d "${projectRoot}/wallpapers" ]]; then
     mkdir -p "$HOME/wallpapers"
     rsync -rtv --delete "${projectRoot}/wallpapers/" "$HOME/wallpapers/"
@@ -688,6 +772,9 @@ main() {
   maybePromptUser
   normalizeMultimediaSelection
   validateConfiguration
+  if [[ $backupConfigs -eq 1 && $skipBackup -eq 0 ]]; then
+    backupUserConfigs
+  fi
   buildPackagePlan
   printSummary
   if [[ $dryRun -eq 1 ]]; then

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -27,20 +27,20 @@ parseGitBranch() {
 
 ### extract
 extract() {
-  if [ -f $1 ]; then
-    case $1 in
-    *.tar.bz2) tar xjf $1 ;;
-    *.tar.gz) tar xzf $1 ;;
-    *.bz2) bunzip2 $1 ;;
-    *.rar) unrar e $1 ;;
-    *.gz) gunzip $1 ;;
-    *.tar) tar xf $1 ;;
-    *.tbz2) tar xjf $1 ;;
-    *.tgz) tar xzf $1 ;;
-    *.zip) unzip $1 ;;
-    *.Z) uncompress $1 ;;
-    *.7z) 7z x $1 ;;
-    *.xz) xz -dk $1 ;;
+  if [ -f "$1" ]; then
+    case "$1" in
+    *.tar.bz2) tar xjf "$1" ;;
+    *.tar.gz) tar xzf "$1" ;;
+    *.bz2) bunzip2 "$1" ;;
+    *.rar) unrar e "$1" ;;
+    *.gz) gunzip "$1" ;;
+    *.tar) tar xf "$1" ;;
+    *.tbz2) tar xjf "$1" ;;
+    *.tgz) tar xzf "$1" ;;
+    *.zip) unzip "$1" ;;
+    *.Z) uncompress "$1" ;;
+    *.7z) 7z x "$1" ;;
+    *.xz) xz -dk "$1" ;;
     *) echo "'$1' cannot be extracted via extract()" ;;
     esac
   else
@@ -86,16 +86,12 @@ case "$OSTYPE" in linux*)
     fi
     ;;
 
-  ID=archlinux )
-    
-    ;;
     esac
 
   alias ..='cd ..'
   alias ls='ls -lsh --color=auto'
   alias ll='ls -lsha --color=auto'
   alias mkdir='mkdir -pv'
-  alias free='free -mt'
   alias ps='ps auxf'
   alias ip='ip -c addr'
   alias psgrep='ps aux | grep -v grep | grep -i -e VSZ -e'

--- a/dotfiles/.colorrc
+++ b/dotfiles/.colorrc
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Make colorcoding available for everyone
 
 Black='\[\e[0;30m\]'    # Black

--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -5,7 +5,7 @@
 #  dash ~/.profile
 #==============================================================================
 
-source ~/.colorrc
+. ~/.colorrc
 
 # Modify this file to reflect your specific requirements
 
@@ -15,11 +15,8 @@ export VISUAL=vim
 
 export PATH="${HOME}/bin:${HOME}/.local/bin:${PATH}"
 
-# enable qt5ct config
-export QT_QPA_PLATFORMTHEME=qt5ct
-
-# determine network interface
-export NET=$(ip route get 2.2.2.2 | awk -- '{printf $5}')
+# enable Kvantum theme engine for Qt apps
+export QT_QPA_PLATFORMTHEME=kvantum
 
 export PS1="${BBlue}\u@\h: ${BCyan}\w${BPurple}\$(parseGitBranch) ${Yellow}\$(date +%H:%M:%S)\n${BCyan}\\$ ${NC}"
 

--- a/dotfiles/root/.bashrc
+++ b/dotfiles/root/.bashrc
@@ -27,20 +27,20 @@ parseGitBranch() {
 
 ### extract
 extract() {
-  if [ -f $1 ]; then
-    case $1 in
-    *.tar.bz2) tar xjf $1 ;;
-    *.tar.gz) tar xzf $1 ;;
-    *.bz2) bunzip2 $1 ;;
-    *.rar) unrar e $1 ;;
-    *.gz) gunzip $1 ;;
-    *.tar) tar xf $1 ;;
-    *.tbz2) tar xjf $1 ;;
-    *.tgz) tar xzf $1 ;;
-    *.zip) unzip $1 ;;
-    *.Z) uncompress $1 ;;
-    *.7z) 7z x $1 ;;
-    *.xz) xz -dk $1 ;;
+  if [ -f "$1" ]; then
+    case "$1" in
+    *.tar.bz2) tar xjf "$1" ;;
+    *.tar.gz) tar xzf "$1" ;;
+    *.bz2) bunzip2 "$1" ;;
+    *.rar) unrar e "$1" ;;
+    *.gz) gunzip "$1" ;;
+    *.tar) tar xf "$1" ;;
+    *.tbz2) tar xjf "$1" ;;
+    *.tgz) tar xzf "$1" ;;
+    *.zip) unzip "$1" ;;
+    *.Z) uncompress "$1" ;;
+    *.7z) 7z x "$1" ;;
+    *.xz) xz -dk "$1" ;;
     *) echo "'$1' cannot be extracted via extract()" ;;
     esac
   else
@@ -86,16 +86,12 @@ case "$OSTYPE" in linux*)
     fi
     ;;
 
-  ID=archlinux )
-    
-    ;;
     esac
 
   alias ..='cd ..'
   alias ls='ls -lsh --color=auto'
   alias ll='ls -lsha --color=auto'
   alias mkdir='mkdir -pv'
-  alias free='free -mt'
   alias ps='ps auxf'
   alias ip='ip -c addr'
   alias psgrep='ps aux | grep -v grep | grep -i -e VSZ -e'

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Name: lib/common.sh
+# Description: Shared functions for DELICE provisioning scripts.
+# Url: https://github.com/TituxMetal/delice
+
+# Display formatted message with green color and borders
+# Usage: printMessage "Your message here"
+printMessage() {
+  local message=$1
+  if command -v tput >/dev/null 2>&1; then
+    tput setaf 2
+  fi
+  echo "-------------------------------------------"
+  echo "$message"
+  echo "-------------------------------------------"
+  if command -v tput >/dev/null 2>&1; then
+    tput sgr0
+  fi
+}
+
+# Log warning message to stderr
+# Usage: logWarning "Warning message"
+logWarning() {
+  local message=$1
+  echo "WARNING: $message" >&2
+}
+
+# Log error message to stderr
+# Usage: logError "Error message"
+logError() {
+  local message=$1
+  echo "ERROR: $message" >&2
+}
+
+# Enable strict error handling with detailed error reporting
+# Sets up trap to show exact line and command that failed
+setupErrorHandling() {
+  set -euo pipefail
+  trap 'status=$?; echo "Error on line ${LINENO}: ${BASH_COMMAND}" >&2; exit $status' ERR
+}
+
+# Ensure script is not run as root user
+# The script needs to run as regular user with sudo privileges for proper file ownership
+# Pass enableRunAsRoot=1 to bypass this check (for testing purposes)
+# Usage: requireUserContext
+requireUserContext() {
+  if [[ "${enableRunAsRoot:-0}" -eq 1 ]]; then
+    return
+  fi
+  if [[ $EUID -eq 0 ]]; then
+    logError "Run this script as a regular user with sudo access."
+    exit 1
+  fi
+}
+
+# Resolve the directory containing the calling script
+# Usage: scriptDir=$(resolveScriptDir)
+resolveScriptDir() {
+  cd "$(dirname "${BASH_SOURCE[1]}")" && pwd
+}

--- a/lvm-commands.md
+++ b/lvm-commands.md
@@ -1,6 +1,6 @@
-# LVM Usefull Commands
+# LVM Useful Commands
 
-## List actual phisical volumes
+## List actual physical volumes
 
 ```
 sudo pvs

--- a/post-install.sh
+++ b/post-install.sh
@@ -1,90 +1,193 @@
 #!/bin/bash
 
-# Run these commands with regular user
+# Name: post-install.sh
+# Description: Base system configuration for Debian 13 (Trixie) — packages, services, firewall, zram, dotfiles.
+# Author: Titux Metal <tituxmetal[at]lgdweb[dot]fr>
+# Url: https://github.com/TituxMetal/delice
+# License: MIT License
+# Target: Debian 13 (Trixie)
 
-printMessage() {
-  message=$1
-  tput setaf 2
-  echo "-------------------------------------------"
-  echo "$message"
-  echo "-------------------------------------------"
-  tput sgr0
+readonly scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly projectRoot="${scriptDir}"
+
+# shellcheck source=lib/common.sh
+source "${scriptDir}/lib/common.sh"
+
+# =============================================================================
+# SCRIPT CONFIGURATION
+# =============================================================================
+
+dryRun=0
+enableRunAsRoot=0
+
+# =============================================================================
+# PACKAGE LISTS
+# =============================================================================
+
+systemPackages="vim htop git bash-completion rsync curl wget chrony modemmanager ufw iwd bind9-dnsutils libnss-mdns avahi-daemon"
+developmentPackages="build-essential libpam0g-dev libxcb-xkb-dev"
+filesystemPackages="fdisk mtools xfsprogs dosfstools zip unzip unrar p7zip-full f2fs-tools exfatprogs gpart udftools"
+monitoringPackages="netselect-apt lynis duf lm-sensors systemd-zram-generator"
+
+enabledServices="chrony ssh avahi-daemon fstrim.timer ufw iwd ModemManager"
+
+# =============================================================================
+# COMMAND LINE PARSING
+# =============================================================================
+
+showHelp() {
+  cat <<'EOF'
+Usage: post-install.sh [options]
+
+Options:
+  --as-root     Run script as root user (not recommended, ONLY for testing)
+  --dry-run     Show planned actions without executing
+  -h, --help    Display this help message
+EOF
 }
 
-# Helper function to handle errors
-handleError() {
-  clear
-  set -uo pipefail
-  trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+parseArgs() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --as-root)
+        enableRunAsRoot=1
+        logWarning "Running as root is not recommended. Proceeding for testing purposes."
+        ;;
+      --dry-run)
+        dryRun=1
+        ;;
+      -h|--help)
+        showHelp
+        exit 0
+        ;;
+      *)
+        logError "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
 }
 
-main() {
-  handleError
+# =============================================================================
+# INSTALLATION FUNCTIONS
+# =============================================================================
 
-  # Make a backup of sources.list file
+updateSourcesList() {
+  printMessage "Updating APT sources to Trixie"
   sudo cp -v /etc/apt/sources.list /etc/apt/sources.list.bak
+  sudo cp -v "${projectRoot}/sources.list" /etc/apt/sources.list
+}
 
-  # Add the new sources.list file
-  sudo cp -v sources.list /etc/apt/sources.list
+upgradeSystem() {
+  printMessage "Running full system upgrade"
+  sudo apt update && sudo apt upgrade -y && sudo apt dist-upgrade -y
+}
 
-  # Make a full system upgrade
-  sudo apt update && sudo apt upgrade && sudo apt dist-upgrade
+installPackages() {
+  printMessage "Installing base packages"
+  sudo apt install -y $systemPackages $developmentPackages $filesystemPackages $monitoringPackages
+}
 
-  # Run this script as regular user
-  sudo apt install -y vim htop git bash-completion rsync curl wget chrony modemmanager ufw iwd bind9-dnsutils libnss-mdns avahi-daemon \
-    build-essential libpam0g-dev libxcb-xkb-dev fdisk mtools xfsprogs dosfstools zip unzip unrar p7zip-full f2fs-tools exfatprogs \
-    gpart udftools netselect-apt lynis duf lm-sensors systemd-zram-generator
+enableServices() {
+  printMessage "Enabling system services"
+  sudo systemctl enable $enabledServices
+}
 
-  sudo systemctl enable chrony ssh avahi-daemon fstrim.timer ufw iwd ModemManager
-
-  # Setup time
+configureTimezone() {
+  printMessage "Configuring timezone and NTP"
   sudo timedatectl set-timezone Europe/Paris --adjust-system-clock
   sudo timedatectl set-ntp yes
+}
 
-  # Setup Ufw firewall
-  sudo ufw default deny incoming && sudo ufw allow ssh && sudo ufw default allow outgoing
+configureFirewall() {
+  printMessage "Configuring UFW firewall"
+  sudo ufw default deny incoming
+  sudo ufw limit ssh
+  sudo ufw default allow outgoing
+}
 
-  # Install and setup Ly display manager
-  # git clone --recurse-submodules https://github.com/fairyglade/ly && cd ly
-  # make && make install installsystemd
-
-  # systemctl enable ly.service && systemctl disable getty@tty2.service
-
-  # Zram configuration
-  sudo bash -c 'cat > "/etc/systemd/zram-generator.conf"' << EOF
+configureZram() {
+  printMessage "Configuring zram swap"
+  sudo tee /etc/systemd/zram-generator.conf >/dev/null <<'ZRAMEOF'
 [zram0]
 zram-size = ram / 2
 compression-algorithm = zstd
 swap-priority = 100
 fs-type = swap
-EOF
+ZRAMEOF
 
   sudo mkdir -pv /etc/sysctl.d
 
-  # Add zram parameters
-  sudo bash -c 'cat > "/etc/sysctl.d/99-vm-zram-parameters.conf"' << EOF
+  sudo tee /etc/sysctl.d/99-vm-zram-parameters.conf >/dev/null <<'SYSCTLEOF'
 vm.swappiness = 180
 vm.watermark_boost_factor = 0
 vm.watermark_scale_factor = 125
 vm.page-cluster = 0
-EOF
+SYSCTLEOF
 
-  # Reload systemd daemon
   sudo systemctl daemon-reload
-  # Start zram
   sudo systemctl start /dev/zram0
-  # Check zram is enabled
   sudo zramctl
-
-  # Add dot files to regular user
-  cp -v dotfiles/.* $HOME/
-  ln -s $HOME/.profile $HOME/.xsessionrc
-
-  # Add dot files to root user
-  sudo -s cp -v dotfiles/root/.* /root/
-
 }
 
-time main
+installDotfiles() {
+  printMessage "Installing dotfiles"
 
-exit 0
+  local dotfile
+  for dotfile in "${projectRoot}"/dotfiles/.bash_profile "${projectRoot}"/dotfiles/.bashrc "${projectRoot}"/dotfiles/.colorrc "${projectRoot}"/dotfiles/.profile; do
+    if [[ -f "$dotfile" ]]; then
+      cp -v "$dotfile" "$HOME/"
+    fi
+  done
+
+  ln -sf "$HOME/.profile" "$HOME/.xsessionrc"
+
+  printMessage "Installing root dotfiles"
+  local rootDotfile
+  for rootDotfile in "${projectRoot}"/dotfiles/root/.bash_profile "${projectRoot}"/dotfiles/root/.bashrc "${projectRoot}"/dotfiles/root/.colorrc "${projectRoot}"/dotfiles/root/.profile; do
+    if [[ -f "$rootDotfile" ]]; then
+      sudo cp -v "$rootDotfile" /root/
+    fi
+  done
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+  setupErrorHandling
+  parseArgs "$@"
+  requireUserContext
+
+  if [[ $dryRun -eq 1 ]]; then
+    printMessage "Dry run — planned actions"
+    echo "- Update sources.list to Trixie"
+    echo "- Full system upgrade"
+    echo "- Install: $systemPackages"
+    echo "- Install: $developmentPackages"
+    echo "- Install: $filesystemPackages"
+    echo "- Install: $monitoringPackages"
+    echo "- Enable services: $enabledServices"
+    echo "- Configure timezone: Europe/Paris"
+    echo "- Configure firewall: deny incoming, limit ssh, allow outgoing"
+    echo "- Configure zram swap"
+    echo "- Install dotfiles"
+    logWarning "Dry run enabled; no changes made."
+    return
+  fi
+
+  updateSourcesList
+  upgradeSystem
+  installPackages
+  enableServices
+  configureTimezone
+  configureFirewall
+  configureZram
+  installDotfiles
+
+  printMessage "Post-install setup complete."
+}
+
+time main "$@"

--- a/sources.list
+++ b/sources.list
@@ -1,15 +1,15 @@
 # Main repo
-deb http://deb.debian.org/debian trixie main contrib non-free non-free-firmware
-deb-src http://deb.debian.org/debian trixie main contrib non-free non-free-firmware
+deb https://deb.debian.org/debian trixie main contrib non-free non-free-firmware
+deb-src https://deb.debian.org/debian trixie main contrib non-free non-free-firmware
 
 # Security repo
-deb http://deb.debian.org/debian-security/ trixie-security main contrib non-free non-free-firmware
-deb-src http://deb.debian.org/debian-security/ trixie-security main contrib non-free non-free-firmware
+deb https://deb.debian.org/debian-security/ trixie-security main contrib non-free non-free-firmware
+deb-src https://deb.debian.org/debian-security/ trixie-security main contrib non-free non-free-firmware
 
 # Updates repo
-deb http://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
-deb-src http://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
+deb https://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
+deb-src https://deb.debian.org/debian trixie-updates main contrib non-free non-free-firmware
 
 # Backports repo
-deb http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware
-deb-src http://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware
+deb https://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware
+deb-src https://deb.debian.org/debian trixie-backports main contrib non-free non-free-firmware

--- a/test-vm.sh
+++ b/test-vm.sh
@@ -61,7 +61,7 @@ export HOME=/home/debian
 $(waitForNetwork)
 
 cd /home/debian/delice
-./post-install.sh 2>&1 | tee -a /var/log/test-output.log
+./post-install.sh --as-root 2>&1 | tee -a /var/log/test-output.log
 echo "TEST_COMPLETE" >> /var/log/test-output.log
 poweroff
 POSTSCRIPT
@@ -78,6 +78,7 @@ injectPostInstallFiles() {
     --copy-in ./post-install.sh:/home/debian/delice/ \
     --copy-in ./sources.list:/home/debian/delice/ \
     --copy-in ./dotfiles:/home/debian/delice/ \
+    --copy-in ./lib:/home/debian/delice/ \
     --copy-in "$script_path":/usr/local/bin/ \
     --copy-in /tmp/rc.local:/etc/ \
     --run-command 'chown -R debian:debian /home/debian/delice' \
@@ -196,7 +197,7 @@ echo "Starting desktop test after post-install backup..." > /var/log/test-output
 $(waitForNetwork)
 
 cd /home/debian/delice
-./desktop-environment.sh 2>&1 | tee -a /var/log/test-output.log
+./desktop-environment.sh --as-root --no-prompts --theme 2>&1 | tee -a /var/log/test-output.log
 echo "TEST_COMPLETE" >> /var/log/test-output.log
 poweroff
 DESKTOPSCRIPT
@@ -206,6 +207,7 @@ DESKTOPSCRIPT
 
   virt-customize -a "$desktop_snapshot" \
     --copy-in ./desktop-environment.sh:/home/debian/delice/ \
+    --copy-in ./lib:/home/debian/delice/ \
     --copy-in ./.config:/home/debian/delice/ \
     --copy-in ./wallpapers:/home/debian/delice/ \
     --copy-in /tmp/run-desktop.sh:/usr/local/bin/ \

--- a/test-vm.sh
+++ b/test-vm.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 set -uo pipefail
 
+readonly VIRT_DIR="${VIRT_MANAGER_DIR:-/home/${USER}/virt-manager}"
 readonly BASE_VM_NAME="debian-stable-base"
 readonly VM_NAME="test-postinstall-$(date +%s)"
-readonly SNAPSHOT_IMAGE="/home/titux/virt-manager/snapshot/${VM_NAME}.qcow2"
+readonly SNAPSHOT_IMAGE="${VIRT_DIR}/snapshot/${VM_NAME}.qcow2"
 readonly LOG_TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 readonly POST_INSTALL_LOG="./test-post-install-${LOG_TIMESTAMP}.log"
 readonly DESKTOP_LOG="./test-desktop-${LOG_TIMESTAMP}.log"
-readonly MEMORY="2048"
-readonly VCPUS="2"
 readonly TIMEOUT=600
 
 readonly POST_INSTALL_BACKUP_NAME="debian-post-install-backup"
-readonly POST_INSTALL_BACKUP_DISK="/home/titux/virt-manager/disk/debian-post-install-backup.qcow2"
+readonly POST_INSTALL_BACKUP_DISK="${VIRT_DIR}/disk/debian-post-install-backup.qcow2"
 
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
 readonly NC='\033[0m'
 
 SCRIPT_TO_TEST=""
@@ -169,13 +167,9 @@ getCloneSource() {
   useBackupSource && echo "$POST_INSTALL_BACKUP_NAME" || echo "$BASE_VM_NAME"
 }
 
-isBackupSource() {
-  [[ "$1" == "$POST_INSTALL_BACKUP_NAME" ]]
-}
-
 runDesktopOnBackup() {
   local desktop_vm_name="test-desktop-$(date +%s)"
-  local desktop_snapshot="/home/titux/virt-manager/snapshot/${desktop_vm_name}.qcow2"
+  local desktop_snapshot="${VIRT_DIR}/snapshot/${desktop_vm_name}.qcow2"
 
   CREATED_VMS+=("$desktop_vm_name")
   CREATED_SNAPSHOTS+=("$desktop_snapshot")
@@ -197,7 +191,7 @@ echo "Starting desktop test after post-install backup..." > /var/log/test-output
 $(waitForNetwork)
 
 cd /home/debian/delice
-./desktop-environment.sh --as-root --no-prompts --theme 2>&1 | tee -a /var/log/test-output.log
+./desktop-environment.sh --as-root --no-prompts --theme --with-brave --with-rustdesk 2>&1 | tee -a /var/log/test-output.log
 echo "TEST_COMPLETE" >> /var/log/test-output.log
 poweroff
 DESKTOPSCRIPT
@@ -208,6 +202,8 @@ DESKTOPSCRIPT
   virt-customize -a "$desktop_snapshot" \
     --copy-in ./desktop-environment.sh:/home/debian/delice/ \
     --copy-in ./lib:/home/debian/delice/ \
+    --copy-in ./configs:/home/debian/delice/ \
+    --copy-in ./tools:/home/debian/delice/ \
     --copy-in ./.config:/home/debian/delice/ \
     --copy-in ./wallpapers:/home/debian/delice/ \
     --copy-in /tmp/run-desktop.sh:/usr/local/bin/ \
@@ -220,23 +216,14 @@ DESKTOPSCRIPT
 
   if ! monitorVMCompletion "$desktop_vm_name" "$TIMEOUT" "Desktop VM"; then
     error "Desktop VM timeout after ${TIMEOUT}s"
-    sudo virsh --connect qemu:///system destroy "$desktop_vm_name" 2>/dev/null || true
-    sudo virsh --connect qemu:///system undefine "$desktop_vm_name" --nvram 2>/dev/null || true
-    rm -f "$desktop_snapshot"
     exit 1
   fi
 
   virt-cat -a "$desktop_snapshot" /var/log/test-output.log > "$DESKTOP_LOG" 2>/dev/null
 
-  echo ""
-  log "Desktop test results (saved to $DESKTOP_LOG):"
-  echo ""
+  showLogSummary "$DESKTOP_LOG" "Desktop"
 
   grep -q "TEST_COMPLETE" "$DESKTOP_LOG" && log "Desktop test completed successfully!" || { error "Desktop test failed or did not complete"; exit 1; }
-
-  sudo virsh --connect qemu:///system destroy "$desktop_vm_name" 2>/dev/null || true
-  sudo virsh --connect qemu:///system undefine "$desktop_vm_name" --nvram 2>/dev/null || true
-  rm -f "$desktop_snapshot"
 }
 
 needsBackupCreation() {
@@ -278,7 +265,7 @@ parseArgs() {
 
 cleanup() {
   log "Cleaning up all created VMs and snapshots"
-  
+
   # Clean up all created VMs
   for vm_name in "${CREATED_VMS[@]}"; do
     [[ -n "$vm_name" ]] || continue
@@ -286,13 +273,16 @@ cleanup() {
     sudo virsh --connect qemu:///system destroy "$vm_name" 2>/dev/null || true
     sudo virsh --connect qemu:///system undefine "$vm_name" --nvram 2>/dev/null || true
   done
-  
+
   # Clean up all created snapshots
   for snapshot in "${CREATED_SNAPSHOTS[@]}"; do
     [[ -n "$snapshot" ]] && [[ -f "$snapshot" ]] || continue
     log "Removing snapshot: $snapshot"
     rm -f "$snapshot"
   done
+
+  # Clean up temporary scripts
+  rm -f /tmp/run-*.sh /tmp/rc.local
 }
 
 isFirstDesktopRun() {
@@ -329,6 +319,7 @@ main() {
   sudo chown $USER:$USER "$SNAPSHOT_IMAGE"
 
   log "Injecting scripts into disk image"
+  # Wait for libvirt to release the qcow2 disk lock after clone
   sleep 3
 
   if isFirstDesktopRun; then
@@ -370,7 +361,7 @@ echo "Starting desktop-only test..." > /var/log/test-output.log
 $(waitForNetwork)
 
 cd /home/debian/delice
-./desktop-environment.sh --as-root --no-prompts --theme 2>&1 | tee -a /var/log/test-output.log
+./desktop-environment.sh --as-root --no-prompts --theme --with-brave --with-rustdesk 2>&1 | tee -a /var/log/test-output.log
 echo "TEST_COMPLETE" >> /var/log/test-output.log
 poweroff
 DESKTOPSCRIPT
@@ -381,6 +372,9 @@ DESKTOPSCRIPT
     # Inject desktop files only
     virt-customize -a "$SNAPSHOT_IMAGE" \
       --copy-in ./desktop-environment.sh:/home/debian/delice/ \
+      --copy-in ./lib:/home/debian/delice/ \
+      --copy-in ./configs:/home/debian/delice/ \
+      --copy-in ./tools:/home/debian/delice/ \
       --copy-in ./.config:/home/debian/delice/ \
       --copy-in ./wallpapers:/home/debian/delice/ \
       --copy-in /tmp/run-desktop-only.sh:/usr/local/bin/ \

--- a/tools/migrate-chrome-to-brave.py
+++ b/tools/migrate-chrome-to-brave.py
@@ -234,7 +234,7 @@ def migrate_passwords(chrome_key, brave_key, dry_run=False):
     shutil.copy2(src, tmp.name)
     conn = sqlite3.connect(tmp.name)
     rows = conn.execute(
-      "SELECT origin_url, action_url, username_value, password_value FROM logins"
+      "SELECT origin_url, action_url, username_value, password_value, signon_realm FROM logins"
     ).fetchall()
     conn.close()
 
@@ -242,7 +242,7 @@ def migrate_passwords(chrome_key, brave_key, dry_run=False):
   skipped = 0
 
   if dry_run:
-    for origin_url, action_url, username, encrypted_pw in rows:
+    for origin_url, action_url, username, encrypted_pw, signon_realm in rows:
       decrypted = decrypt_password(encrypted_pw, chrome_key)
       if decrypted:
         migrated += 1
@@ -257,10 +257,11 @@ def migrate_passwords(chrome_key, brave_key, dry_run=False):
     tmp_path = tmp.name
     shutil.copy2(dst, tmp_path)
 
+  conn = None
   try:
     conn = sqlite3.connect(tmp_path)
 
-    for origin_url, action_url, username, encrypted_pw in rows:
+    for origin_url, action_url, username, encrypted_pw, signon_realm in rows:
       decrypted = decrypt_password(encrypted_pw, chrome_key)
       if not decrypted:
         skipped += 1
@@ -280,8 +281,9 @@ def migrate_passwords(chrome_key, brave_key, dry_run=False):
 
       conn.execute(
         "INSERT INTO logins (origin_url, action_url, username_value, password_value, "
-        "date_created, blacklisted_by_user, scheme) VALUES (?, ?, ?, ?, ?, 0, 0)",
-        (origin_url, action_url, username, re_encrypted, 0)
+        "signon_realm, date_created, blacklisted_by_user, scheme) "
+        "VALUES (?, ?, ?, ?, ?, 0, 0, 0)",
+        (origin_url, action_url, username, re_encrypted, signon_realm)
       )
       migrated += 1
 
@@ -293,7 +295,8 @@ def migrate_passwords(chrome_key, brave_key, dry_run=False):
     print(f"Migrated {migrated} passwords ({skipped} skipped/duplicates)")
 
   except Exception as e:
-    conn.close()
+    if conn:
+      conn.close()
     os.unlink(tmp_path)
     print(f"Error migrating passwords: {e}")
     return 0

--- a/tools/migrate-chrome-to-brave.py
+++ b/tools/migrate-chrome-to-brave.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+
+"""
+Migrate Chrome data (bookmarks, history, passwords) to Brave browser.
+
+Dependencies: python3-secretstorage, python3-cryptography
+Usage: migrate-chrome-to-brave.py [--dry-run]
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+try:
+  import secretstorage
+except ImportError:
+  print("Error: python3-secretstorage is required. Install with: sudo apt install python3-secretstorage")
+  sys.exit(1)
+
+try:
+  from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+  from cryptography.hazmat.primitives import padding
+except ImportError:
+  print("Error: python3-cryptography is required. Install with: sudo apt install python3-cryptography")
+  sys.exit(1)
+
+
+CHROME_DIR = Path.home() / ".config" / "google-chrome" / "Default"
+BRAVE_DIR = Path.home() / ".config" / "BraveSoftware" / "Brave-Browser" / "Default"
+
+# Chromium on Linux uses PBKDF2 with these fixed parameters
+PBKDF2_SALT = b"saltysalt"
+PBKDF2_ITERATIONS = 1
+PBKDF2_KEY_LENGTH = 16
+AES_IV = b" " * 16  # 16 spaces
+CHROMIUM_PASSWORD_PREFIX = b"v10"
+
+
+def check_browser_running(process_name):
+  """Check if a browser process is currently running."""
+  try:
+    result = subprocess.run(
+      ["pgrep", "-f", process_name],
+      capture_output=True, text=True
+    )
+    return result.returncode == 0
+  except FileNotFoundError:
+    return False
+
+
+def get_encryption_key(application):
+  """Read the encryption key from GNOME Keyring for a Chromium-based browser.
+
+  Chrome stores under 'Chrome Safe Storage', Brave under 'Brave Safe Storage'.
+  """
+  connection = secretstorage.dbus_init()
+  collection = secretstorage.get_default_collection(connection)
+
+  if collection.is_locked():
+    collection.unlock()
+
+  for item in collection.get_all_items():
+    if item.get_label() == f"{application} Safe Storage":
+      secret = item.get_secret()
+      return hashlib.pbkdf2_hmac(
+        "sha1", secret, PBKDF2_SALT, PBKDF2_ITERATIONS, PBKDF2_KEY_LENGTH
+      )
+
+  return None
+
+
+def get_chrome_key():
+  """Read Chrome encryption key from GNOME Keyring."""
+  return get_encryption_key("Chrome")
+
+
+def get_brave_key():
+  """Read Brave encryption key from GNOME Keyring."""
+  return get_encryption_key("Brave")
+
+
+def decrypt_password(encrypted, key):
+  """Decrypt a Chromium-encrypted password using AES-128-CBC."""
+  if not encrypted or not encrypted.startswith(CHROMIUM_PASSWORD_PREFIX):
+    return None
+
+  encrypted_data = encrypted[len(CHROMIUM_PASSWORD_PREFIX):]
+
+  if not encrypted_data:
+    return None
+
+  cipher = Cipher(algorithms.AES(key), modes.CBC(AES_IV))
+  decryptor = cipher.decryptor()
+  decrypted_padded = decryptor.update(encrypted_data) + decryptor.finalize()
+
+  # Remove PKCS7 padding
+  unpadder = padding.PKCS7(128).unpadder()
+  decrypted = unpadder.update(decrypted_padded) + unpadder.finalize()
+
+  return decrypted.decode("utf-8")
+
+
+def encrypt_password(plaintext, key):
+  """Encrypt a password for a Chromium-based browser using AES-128-CBC."""
+  padder = padding.PKCS7(128).padder()
+  padded_data = padder.update(plaintext.encode("utf-8")) + padder.finalize()
+
+  cipher = Cipher(algorithms.AES(key), modes.CBC(AES_IV))
+  encryptor = cipher.encryptor()
+  encrypted = encryptor.update(padded_data) + encryptor.finalize()
+
+  return CHROMIUM_PASSWORD_PREFIX + encrypted
+
+
+def backup_profiles(dry_run=False):
+  """Backup Chrome and Brave profiles before migration."""
+  timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+  backup_base = Path.home() / f"delice-migration-backup-{timestamp}"
+
+  profiles = []
+  if CHROME_DIR.exists():
+    profiles.append(("chrome", CHROME_DIR))
+  if BRAVE_DIR.exists():
+    profiles.append(("brave", BRAVE_DIR))
+
+  if dry_run:
+    print(f"[DRY RUN] Would backup profiles to: {backup_base}")
+    for name, path in profiles:
+      print(f"  - {name}: {path}")
+    return True
+
+  print(f"Backing up profiles to: {backup_base}")
+  backup_base.mkdir(parents=True, exist_ok=True)
+
+  for name, path in profiles:
+    dest = backup_base / name
+    dest.mkdir(parents=True, exist_ok=True)
+    for filename in ["Bookmarks", "History", "Login Data"]:
+      src_file = path / filename
+      if src_file.exists():
+        shutil.copy2(src_file, dest / filename)
+        print(f"  Backed up {name}/{filename}")
+
+  print(f"Backup complete: {backup_base}")
+  return True
+
+
+def migrate_bookmarks(dry_run=False):
+  """Migrate bookmarks from Chrome to Brave by copying the JSON file."""
+  src = CHROME_DIR / "Bookmarks"
+  dst = BRAVE_DIR / "Bookmarks"
+
+  if not src.exists():
+    print("No Chrome bookmarks found, skipping.")
+    return 0
+
+  if dry_run:
+    with open(src, "r") as f:
+      data = json.load(f)
+    count = count_bookmarks(data.get("roots", {}))
+    print(f"[DRY RUN] Would migrate {count} bookmarks")
+    return count
+
+  shutil.copy2(src, dst)
+  with open(src, "r") as f:
+    data = json.load(f)
+  count = count_bookmarks(data.get("roots", {}))
+  print(f"Migrated {count} bookmarks")
+  return count
+
+
+def count_bookmarks(node):
+  """Recursively count bookmarks in a bookmarks JSON structure."""
+  count = 0
+  if isinstance(node, dict):
+    if node.get("type") == "url":
+      return 1
+    for value in node.values():
+      count += count_bookmarks(value)
+  elif isinstance(node, list):
+    for item in node:
+      count += count_bookmarks(item)
+  return count
+
+
+def migrate_history(dry_run=False):
+  """Migrate browsing history from Chrome to Brave by copying the SQLite database."""
+  src = CHROME_DIR / "History"
+  dst = BRAVE_DIR / "History"
+
+  if not src.exists():
+    print("No Chrome history found, skipping.")
+    return 0
+
+  # Count entries for reporting
+  with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+    shutil.copy2(src, tmp.name)
+    conn = sqlite3.connect(tmp.name)
+    count = conn.execute("SELECT COUNT(*) FROM urls").fetchone()[0]
+    conn.close()
+
+  if dry_run:
+    print(f"[DRY RUN] Would migrate {count} history entries")
+    return count
+
+  shutil.copy2(src, dst)
+  print(f"Migrated {count} history entries")
+  return count
+
+
+def migrate_passwords(chrome_key, brave_key, dry_run=False):
+  """Migrate passwords: decrypt from Chrome, re-encrypt for Brave, insert into Brave DB."""
+  src = CHROME_DIR / "Login Data"
+  dst = BRAVE_DIR / "Login Data"
+
+  if not src.exists():
+    print("No Chrome passwords found, skipping.")
+    return 0
+
+  if not dst.exists():
+    print("Brave Login Data not found. Launch Brave at least once first.")
+    return 0
+
+  # Read Chrome passwords from a temporary copy (avoid lock issues)
+  with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+    shutil.copy2(src, tmp.name)
+    conn = sqlite3.connect(tmp.name)
+    rows = conn.execute(
+      "SELECT origin_url, action_url, username_value, password_value FROM logins"
+    ).fetchall()
+    conn.close()
+
+  migrated = 0
+  skipped = 0
+
+  if dry_run:
+    for origin_url, action_url, username, encrypted_pw in rows:
+      decrypted = decrypt_password(encrypted_pw, chrome_key)
+      if decrypted:
+        migrated += 1
+        print(f"  [DRY RUN] {origin_url} ({username})")
+      else:
+        skipped += 1
+    print(f"[DRY RUN] Would migrate {migrated} passwords ({skipped} skipped)")
+    return migrated
+
+  # Work on a copy of Brave's Login Data
+  with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+    tmp_path = tmp.name
+    shutil.copy2(dst, tmp_path)
+
+  try:
+    conn = sqlite3.connect(tmp_path)
+
+    for origin_url, action_url, username, encrypted_pw in rows:
+      decrypted = decrypt_password(encrypted_pw, chrome_key)
+      if not decrypted:
+        skipped += 1
+        continue
+
+      # Check if this login already exists in Brave
+      existing = conn.execute(
+        "SELECT COUNT(*) FROM logins WHERE origin_url = ? AND username_value = ?",
+        (origin_url, username)
+      ).fetchone()[0]
+
+      if existing > 0:
+        skipped += 1
+        continue
+
+      re_encrypted = encrypt_password(decrypted, brave_key)
+
+      conn.execute(
+        "INSERT INTO logins (origin_url, action_url, username_value, password_value, "
+        "date_created, blacklisted_by_user, scheme) VALUES (?, ?, ?, ?, ?, 0, 0)",
+        (origin_url, action_url, username, re_encrypted, 0)
+      )
+      migrated += 1
+
+    conn.commit()
+    conn.close()
+
+    # Replace Brave's Login Data with the modified copy
+    shutil.move(tmp_path, dst)
+    print(f"Migrated {migrated} passwords ({skipped} skipped/duplicates)")
+
+  except Exception as e:
+    conn.close()
+    os.unlink(tmp_path)
+    print(f"Error migrating passwords: {e}")
+    return 0
+
+  return migrated
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description="Migrate Chrome data (bookmarks, history, passwords) to Brave browser."
+  )
+  parser.add_argument(
+    "--dry-run", action="store_true",
+    help="Show what would be migrated without making changes"
+  )
+  args = parser.parse_args()
+
+  # Pre-flight checks
+  if not CHROME_DIR.exists():
+    print(f"Error: Chrome profile not found at {CHROME_DIR}")
+    sys.exit(1)
+
+  if not BRAVE_DIR.exists():
+    print(f"Error: Brave profile not found at {BRAVE_DIR}")
+    print("Launch Brave at least once to create the profile, then retry.")
+    sys.exit(1)
+
+  if check_browser_running("chrome"):
+    print("Error: Google Chrome is running. Close it before migrating.")
+    sys.exit(1)
+
+  if check_browser_running("brave"):
+    print("Error: Brave browser is running. Close it before migrating.")
+    sys.exit(1)
+
+  print("=== Chrome to Brave Migration ===")
+  if args.dry_run:
+    print("[DRY RUN MODE — no changes will be made]\n")
+
+  # Backup before migration
+  backup_profiles(dry_run=args.dry_run)
+  print()
+
+  # Migrate bookmarks
+  migrate_bookmarks(dry_run=args.dry_run)
+  print()
+
+  # Migrate history
+  migrate_history(dry_run=args.dry_run)
+  print()
+
+  # Migrate passwords
+  chrome_key = get_chrome_key()
+  brave_key = get_brave_key()
+
+  if not chrome_key:
+    print("Warning: Chrome encryption key not found in GNOME Keyring.")
+    print("Password migration skipped.")
+  elif not brave_key:
+    print("Warning: Brave encryption key not found in GNOME Keyring.")
+    print("Password migration skipped.")
+  else:
+    migrate_passwords(chrome_key, brave_key, dry_run=args.dry_run)
+
+  print("\n=== Migration complete ===")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary

Evolution of DELICE from a fresh installation tool to a provisioning and maintenance toolkit capable of running on existing Debian machines (12 → 13) without data loss.

### Changes

- **Foundations**: Extract shared functions into `lib/common.sh`, refactor `post-install.sh` with proper error handling
- **Upgrade Safety**: User config backup system, selective per-subdirectory rsync (no more `rsync --delete` on `~/.config/`)
- **Brave Browser**: APT repo + GPG keyring, managed policies (uBlock Origin forced, Rewards/Wallet/VPN disabled), Chrome uninstall prompt
- **Chrome Migration**: Python script for bookmarks, history, and encrypted password migration via GNOME Keyring
- **Rustdesk**: Install from GitHub releases, self-hosted server configuration (laura.lgdweb.ovh)
- **Dark Theme**: Arc-Dark (GTK) + KvArcDark (Qt/Kvantum), `gtk-application-prefer-dark-theme`
- **Wallpaper**: Dynamic path resolution via `DELICE_WALLPAPER` placeholder + `configureWallpaper()`
- **Test Framework**: Configurable VM paths, dead code cleanup, inject new dirs, `--with-brave --with-rustdesk` in test commands
- **Documentation**: Updated README with all CLI flags, created CHANGELOG

### Known Issues

- VLC and Brave dark theme not fully working on fresh Debian install (needs investigation)
- `SUDO_USER` HOME fix is a workaround — script should ideally not need sudo at all for config sync

## Test plan

- [x] `./test-vm.sh` — post-install passes
- [x] `./test-vm.sh --desktop` — desktop with Brave + Rustdesk passes
- [x] Manual VM test — dark theme on GTK apps (PCManFM, Firefox, galculator, LibreOffice)
- [ ] VLC Qt5 dark theme
- [ ] Brave dark mode
- [ ] Upgrade scenario (existing configs preserved)
- [ ] Chrome → Brave migration